### PR TITLE
尝试在windows平台下编译，成功，将编译步骤记录备忘

### DIFF
--- a/BUILD.mingw.md
+++ b/BUILD.mingw.md
@@ -1,0 +1,17 @@
+# Windows 平台编译指南
+
+1. 先安装 Ming-w64 + Mingw-GCC 工具链，并把 gcc.exe 所在的路径加到 PATH 变量里
+2. 安装 cmake
+3. 到 https://taglib.org/ 下载 taglib 的源码包，或者直接下载最新的 
+   https://taglib.org/releases/taglib-1.11.1.tar.gz
+4. 解压到一个目录里，例如 C:/Temp/taglib-1.11.1，然后在同级建立一个目录 C:/Temp/build
+5. 打开命令行，cd 到 C:/Temp/build 里，然后执行以下命令编译 taglib 库
+
+```
+cmake -G "MinGW Makefiles" ..\taglib-1.11.1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Temp/taglib
+make -j4
+make install
+```
+
+6. 下载 ncmdump，比如到 C:/Temp/ncmdump，修改Makefile里的TAGLIB_PATH，然后 `make -f Makefile.mingw` 就 OK了。
+

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,0 +1,11 @@
+TAGLIB_PATH	= C:/Temp/taglib
+
+CFLAGS	+= -I $(TAGLIB_PATH)/include
+CFLAGS	+= -D TAGLIB_STATIC
+
+LDFLAGS	+= -L $(TAGLIB_PATH)/lib
+LIBS	+= -ltag -lz
+
+all:
+	g++ $(CFLAGS) $(LDFLAGS) main.cpp cJSON.cpp aes.cpp ncmcrypt.cpp -o ncmdump $(LIBS)
+

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -2,6 +2,7 @@ TAGLIB_PATH	= C:/Temp/taglib
 
 CFLAGS	+= -I $(TAGLIB_PATH)/include
 CFLAGS	+= -D TAGLIB_STATIC
+CFLAGS	+= -static
 
 LDFLAGS	+= -L $(TAGLIB_PATH)/lib
 LIBS	+= -ltag -lz


### PR DESCRIPTION
测试环境：
- 通过 msys64 安装的 mingw-w64-x86_64-gcc
- gcc version 9.3.0 (Rev1, Built by MSYS2 project)
- taglib-1.11.1
- ncmdump-f9f6e2f1746d7eaf0e2c08eb61fde91d94dbfbb5

在Windows下能编译并正常执行，exe信息：
```
ncmdump.exe: PE32+ executable (console) x86_64 (Sat Jul 11 22:02:54 2020)
  Import KERNEL32.dll
  Import msvcrt.dll
  Export ncmdump.exe
```